### PR TITLE
CDNのリンクにバージョン固定を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:locale" content="ja_JP" />
     <link rel="stylesheet" href="assets/styles/main.css"></link>
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
     <script src="assets/scripts/lib/marked.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-77941335-3"></script>


### PR DESCRIPTION
いつも便利に使わせていただいております。

おそらくVue 2.xを前提としたページかと思うのですが、
現在はVueのCDNを指定した際、バージョン指定がないと自動でVue3がロードされるようです。

明示的にVue2.6.14を指定するように変更させていただきましたところローカルで動作しましたのでプルリクエストを作成させていただきます。
